### PR TITLE
Add turtle script for Horsforth School illustration

### DIFF
--- a/horsforth_school_turtle.py
+++ b/horsforth_school_turtle.py
@@ -1,0 +1,111 @@
+from turtle import *
+
+# Screen setup
+setup(800, 600)
+bgcolor("skyblue")
+speed(0)
+hideturtle()
+
+# Utility functions
+
+def draw_rectangle(x, y, width, height, color_name):
+    penup()
+    goto(x, y)
+    color(color_name)
+    begin_fill()
+    for _ in range(2):
+        forward(width)
+        left(90)
+        forward(height)
+        left(90)
+    end_fill()
+
+
+def draw_triangle(x, y, width, height, color_name):
+    penup()
+    goto(x, y)
+    color(color_name)
+    begin_fill()
+    goto(x + width / 2, y + height)
+    goto(x + width, y)
+    goto(x, y)
+    end_fill()
+
+
+def draw_horse_logo(x, y, scale=1.0):
+    penup()
+    goto(x, y)
+    pendown()
+    color("black")
+    pensize(2)
+
+    # Body
+    begin_fill()
+    circle(20 * scale)
+    end_fill()
+
+    # Neck and head
+    penup()
+    goto(x + 20 * scale, y + 20 * scale)
+    pendown()
+    goto(x + 35 * scale, y + 50 * scale)
+    begin_fill()
+    circle(8 * scale)
+    end_fill()
+
+    # Front legs (raised)
+    penup()
+    goto(x + 15 * scale, y + 10 * scale)
+    pendown()
+    goto(x + 35 * scale, y + 40 * scale)
+    penup()
+    goto(x + 5 * scale, y + 10 * scale)
+    pendown()
+    goto(x + 25 * scale, y + 40 * scale)
+
+    # Hind legs
+    penup()
+    goto(x - 15 * scale, y - 20 * scale)
+    pendown()
+    goto(x, y)
+    goto(x - 5 * scale, y - 20 * scale)
+    goto(x, y)
+
+    # Tail
+    penup()
+    goto(x - 20 * scale, y + 10 * scale)
+    pendown()
+    goto(x - 40 * scale, y + 20 * scale)
+
+
+def draw_scene():
+    # Grass
+    draw_rectangle(-400, -200, 800, 100, "green")
+
+    # School building
+    draw_rectangle(-150, -100, 300, 200, "red")
+
+    # Roof
+    draw_triangle(-160, 100, 320, 80, "maroon")
+
+    # Door
+    draw_rectangle(-30, -100, 60, 100, "brown")
+
+    # Windows
+    draw_rectangle(-120, 0, 60, 40, "white")
+    draw_rectangle(60, 0, 60, 40, "white")
+
+    # Horsforth School logo (horse)
+    draw_horse_logo(0, 50, 1)
+
+    # Text above the school
+    penup()
+    goto(0, 200)
+    color("purple")
+    write("Horsforth School", align="center", font=("Arial", 32, "bold"))
+
+    done()
+
+
+if __name__ == "__main__":
+    draw_scene()


### PR DESCRIPTION
## Summary
- add `horsforth_school_turtle.py` showing a simple red school with doors and windows
- include a horse logo and purple text label
- draw green grass and a blue sky using Python turtle

## Testing
- `python horsforth_school_turtle.py`

------
https://chatgpt.com/codex/tasks/task_e_6851414b90c88325aa244aa30a0df35a